### PR TITLE
Error testing on curvature estimation

### DIFF
--- a/mes_examples/example_curvature.py
+++ b/mes_examples/example_curvature.py
@@ -15,6 +15,9 @@ example of curvature estimation in slam
 
 ###############################################################################
 # importation of slam modules
+import slam.utils as ut
+import numpy as np
+import slam.generate_parametric_surfaces as sgps
 import slam.io as sio
 import slam.plot as splt
 import slam.curvature as scurv
@@ -70,4 +73,120 @@ visb_sc = splt.visbrain_plot(mesh=mesh, tex=curvedness,
                              caption='Curvedness',
                              cblabel='Curvedness',
                              cmap='hot')
+visb_sc.preview()
+
+
+###############################################################################
+# Estimation error on the principal curvature length
+K = [1, 0]
+
+quadric = sgps.generate_quadric(
+    K,
+    nstep=[
+        20,
+        20],
+    ax=3,
+    ay=3,
+    random_sampling=False,
+    ratio=0.3,
+    random_distribution_type='gamma', equilateral=True)
+
+###############################################################################
+# Estimated computation of the Principal curvature, K_gauss, K_mean
+p_curv, d1_estim, d2_estim = scurv.curvatures_and_derivatives(
+    quadric)
+
+k1_estim, k2_estim = p_curv[0, :], p_curv[1, :]
+
+k_gauss_estim = k1_estim * k2_estim
+
+k_mean_estim = .5 * (k1_estim + k2_estim)
+
+###############################################################################
+# Analytical computation of the curvatures
+
+k_mean_analytic = sgps.quadric_curv_mean(K)(
+    np.array(quadric.vertices[:, 0]), np.array(quadric.vertices[:, 1]))
+
+k_gauss_analytic = sgps.quadric_curv_gauss(K)(
+    np.array(quadric.vertices[:, 0]), np.array(quadric.vertices[:, 1]))
+
+k1_analytic = np.zeros((len(k_mean_analytic)))
+k2_analytic = np.zeros((len(k_mean_analytic)))
+
+for i in range(len(k_mean_analytic)):
+    a, b = np.roots(
+        (1, -2 * k_mean_analytic[i], k_gauss_analytic[i]))
+    k1_analytic[i] = min(a, b)
+    k2_analytic[i] = max(a, b)
+
+
+###############################################################################
+# Error computation
+
+k_mean_relative_change = abs(
+    (k_mean_analytic - k_mean_estim) / k_mean_analytic)
+k_mean_absolute_change = abs((k_mean_analytic - k_mean_estim))
+
+k1_relative_change = abs((k1_analytic - k1_estim) / k1_analytic)
+k1_absolute_change = abs((k1_analytic - k1_estim))
+
+###############################################################################
+# Error plot
+
+visb_sc = splt.visbrain_plot(mesh=quadric, tex=k_mean_absolute_change,
+                             caption='K_mean absolute error',
+                             cblabel='K_mean absolute error',)
+visb_sc.preview()
+
+###############################################################################
+# Estimation error on the curvature directions
+
+
+K = [1, 0]
+
+quadric = sgps.generate_quadric(
+    K,
+    nstep=[
+        20,
+        20],
+    ax=3,
+    ay=3,
+    random_sampling=False,
+    ratio=0.3,
+    random_distribution_type='gamma', equilateral=True)
+
+###############################################################################
+# Estimated computation of the Principal curvature, Direction1, Direction2
+p_curv_estim, d1_estim, d2_estim = scurv.curvatures_and_derivatives(
+    quadric)
+
+###############################################################################
+# Analytical computation of the directions
+analytical_directions = sgps.compute_all_principal_directions_3D(
+    K, quadric.vertices)
+
+estimated_directions = np.zeros(analytical_directions.shape)
+estimated_directions[:, :, 0] = d1_estim
+estimated_directions[:, :, 1] = d2_estim
+
+angular_error_0, dotprods = ut.compare_analytic_estimated_directions(
+    analytical_directions[:, :, 0], estimated_directions)
+angular_error_0 = 180 * angular_error_0 / np.pi
+
+angular_error_1, dotprods = ut.compare_analytic_estimated_directions(
+    analytical_directions[:, :, 1], estimated_directions)
+angular_error_1 = 180 * angular_error_1 / np.pi
+
+###############################################################################
+# Error plot
+
+visb_sc = splt.visbrain_plot(mesh=quadric, tex=angular_error_0,
+                             caption='Angular error 0',
+                             cblabel='Angular error 0',)
+visb_sc.preview()
+
+visb_sc = splt.visbrain_plot(mesh=quadric, tex=angular_error_1,
+                             caption='Angular error 1',
+                             cblabel='Angular error 1',)
 visb_sc.preview()

--- a/tests/test_curvature.py
+++ b/tests/test_curvature.py
@@ -259,7 +259,7 @@ class TestCurvatureMethods(unittest.TestCase):
         # points
         assert(sorted(out, reverse=True) == out)
 
-    def test_error_drop_curvature_quadric(self):
+    def test_error_drop_curvature_sphere(self):
 
         out = []
 
@@ -303,7 +303,7 @@ class TestCurvatureMethods(unittest.TestCase):
                 shapeIndex, -1, precisionA)).all()
         assert(np.isclose(curvedness, 1 / radius, precisionB).all())
 
-    def test_correctness_decomposition_quadrix(self):
+    def test_correctness_decomposition_quadric(self):
 
         # Precision on the shapeIndex calculation
         precisionA = 0.000001

--- a/tests/test_distortion.py
+++ b/tests/test_distortion.py
@@ -1,12 +1,89 @@
+import slam.io as sio
+import slam.distortion as sdst
+import numpy as np
+import unittest
+import trimesh
+
+# UTILITIES
 
 
-def test_angle_difference():
-    assert True
+def make_sphere(radius=1):
+    """ Create a sphere"""
+    mesh_a = trimesh.creation.icosphere(subdivisions=1, radius=radius)
+    return mesh_a
 
 
-def test_area_difference():
-    assert True
+class TestDistortionMethods(unittest.TestCase):
+
+    # Spheres
+    sphere_r1 = make_sphere(1)
+    sphere_r2 = make_sphere(2)
+
+    def test_basic(self):
+        mesh_a = self.sphere_r1.copy()
+        mesh_a_save = self.sphere_r1.copy()
+
+        mesh_b = self.sphere_r2.copy()
+        mesh_b_save = self.sphere_r2.copy()
+
+        tmp = sdst.angle_difference(mesh_a, mesh_b)
+
+        assert(mesh_a.vertices == mesh_a_save.vertices).all()
+        assert(mesh_a.faces == mesh_a_save.faces).all()
+
+        assert(mesh_b.vertices == mesh_b_save.vertices).all()
+        assert(mesh_b.faces == mesh_b_save.faces).all()
+
+        tmp = sdst.area_difference(mesh_a, mesh_b)
+
+        assert(mesh_a.vertices == mesh_a_save.vertices).all()
+        assert(mesh_a.faces == mesh_a_save.faces).all()
+
+        assert(mesh_b.vertices == mesh_b_save.vertices).all()
+        assert(mesh_b.faces == mesh_b_save.faces).all()
+
+        tmp = sdst.edge_length_difference(mesh_a, mesh_b)
+
+        assert(mesh_a.vertices == mesh_a_save.vertices).all()
+        assert(mesh_a.faces == mesh_a_save.faces).all()
+
+        assert(mesh_b.vertices == mesh_b_save.vertices).all()
+        assert(mesh_b.faces == mesh_b_save.faces).all()
+
+    def test_correctness_area(self):
+
+        precisionA = .001
+
+        n_sub = 5
+
+        mesh_a = trimesh.creation.icosphere(subdivisions=n_sub, radius=1)
+        mesh_b = trimesh.creation.icosphere(subdivisions=n_sub, radius=2)
+
+        area_diff_estim = sdst.area_difference(mesh_a, mesh_b)
+
+        area_diff_estim = sum(abs(area_diff_estim))
+
+        area_diff_analytical = 4 * np.pi * 2 * 2 - 4 * np.pi * 1 * 1
+
+        assert(np.isclose(area_diff_estim, area_diff_analytical, precisionA))
+
+    def test_correctness_angle(self):
+
+        precisionA = .001
+
+        n_sub = 5
+
+        mesh_a = trimesh.creation.icosphere(subdivisions=n_sub, radius=1)
+        mesh_b = trimesh.creation.icosphere(subdivisions=n_sub, radius=2)
+
+        angle_diff_estim = sdst.angle_difference(mesh_a, mesh_b)
+
+        angle_diff_estim = sum(sum(abs(angle_diff_estim)))
+
+        angle_diff_analytical = 0
+
+        assert(np.isclose(angle_diff_estim, angle_diff_analytical, precisionA))
 
 
-def test_edge_length_difference():
-    assert True
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- J'ai ajouté un test sur l'erreur des directions de courbures en reprenant [le script de Mr. Lefèvre](https://github.com/gauzias/curvature_simulations/blob/master/simulations_principal_curvatures.py) sur `test_curvature.py`.
- J'ai ajouté des visualisations à l'exemple des courbures, comme on en avait parlé la dernière fois. Pour le moment, l'erreur sur la courbure principale semble plus forte au centre de la quadrique, avec toujours une valeur assez haute comparée au 10-5 attendu. Pour l'erreur sur la direction de courbure, elle est plus dispersée, et je retrouve bien un histogramme correspondant à celui de Mr. Lefèvre (qui fait partie du test, je vérifie que plus de 75% des directions calculées varient de moins de 20 degrés par rapport aux directions analytiques).
Comme l'erreur sur la courbure principale est toujours très forte, j'ai laissé le skip du test sur ce paramètre.
- J'ai rajouté une classe de test de distortion.py que j'avais oublié de commit quand je l'avais faite.

Erreur sur la courbure principale:

![azeazea](https://user-images.githubusercontent.com/47481790/88181988-e70adf00-cc2f-11ea-9c65-11379e1387a8.png)

Erreur sur la direction de courbure 1:

![azeazeazr](https://user-images.githubusercontent.com/47481790/88182395-6ef0e900-cc30-11ea-8eb6-8974ee9605e8.png)


J'ai obtenu ces visualisations à partir d'un script semblable à celui que j'ai push dans `exemple_curvature.py`.